### PR TITLE
Unreal Engine 5.4 support

### DIFF
--- a/MovementSample.uproject
+++ b/MovementSample.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "5.3",
+	"EngineAssociation": "5.4",
 	"Category": "",
 	"Description": "",
 	"Modules": [

--- a/Plugins/OculusXRRetargeting/Source/OculusXRRetargetingEditor/Private/OculusXRRetargetIKRetargeterEditor.cpp
+++ b/Plugins/OculusXRRetargeting/Source/OculusXRRetargetingEditor/Private/OculusXRRetargetIKRetargeterEditor.cpp
@@ -76,18 +76,36 @@ void UOculusXRRetargetIKRetargeterEditor::ValidateAnimNodeDuringCompilation(USke
 	}
 
 	// validate SOURCE IK Rig asset has been assigned
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 4
+	if (!Node.IKRetargeterAsset->GetIKRig(ERetargetSourceOrTarget::Source))
+	{
+		MessageLog.Warning(TEXT("@@ has IK Retargeter that is missing a source IK Rig asset."), this);
+	}
+#else
 	if (!Node.IKRetargeterAsset->GetSourceIKRig())
 	{
 		MessageLog.Warning(TEXT("@@ has IK Retargeter that is missing a source IK Rig asset."), this);
 	}
+#endif
 
 	// validate TARGET IK Rig asset has been assigned
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 4
+	if (!Node.IKRetargeterAsset->GetIKRig(ERetargetSourceOrTarget::Target))
+	{
+		MessageLog.Warning(TEXT("@@ has IK Retargeter that is missing a target IK Rig asset."), this);
+	}
+#else
 	if (!Node.IKRetargeterAsset->GetTargetIKRig())
 	{
 		MessageLog.Warning(TEXT("@@ has IK Retargeter that is missing a target IK Rig asset."), this);
 	}
+#endif
 
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 4
+	if (!(Node.IKRetargeterAsset->GetIKRig(ERetargetSourceOrTarget::Source) && Node.IKRetargeterAsset->GetIKRig(ERetargetSourceOrTarget::Target)))
+#else
 	if (!(Node.IKRetargeterAsset->GetSourceIKRig() && Node.IKRetargeterAsset->GetTargetIKRig()))
+#endif
 	{
 		return;
 	}
@@ -115,7 +133,11 @@ void UOculusXRRetargetIKRetargeterEditor::ValidateAnimNodeDuringCompilation(USke
 	{
 		// validate that target bone chains exist on this skeleton
 		const FReferenceSkeleton& RefSkel = ForSkeleton->GetReferenceSkeleton();
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 4
+		const TArray<FBoneChain>& TargetBoneChains = Node.IKRetargeterAsset->GetIKRig(ERetargetSourceOrTarget::Target)->GetRetargetChains();
+#else
 		const TArray<FBoneChain>& TargetBoneChains = Node.IKRetargeterAsset->GetTargetIKRig()->GetRetargetChains();
+#endif
 		for (const FBoneChain& Chain : TargetBoneChains)
 		{
 			if (RefSkel.FindBoneIndex(Chain.StartBone.BoneName) == INDEX_NONE)
@@ -131,6 +153,7 @@ void UOculusXRRetargetIKRetargeterEditor::ValidateAnimNodeDuringCompilation(USke
 	}
 }
 
+
 void UOculusXRRetargetIKRetargeterEditor::PreloadRequiredAssets()
 {
 	Super::PreloadRequiredAssets();
@@ -138,9 +161,15 @@ void UOculusXRRetargetIKRetargeterEditor::PreloadRequiredAssets()
 	if (Node.IKRetargeterAsset)
 	{
 		PreloadObject(Node.IKRetargeterAsset);
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 4
+		PreloadObject(Node.IKRetargeterAsset->GetIKRigWriteable(ERetargetSourceOrTarget::Source));
+		PreloadObject(Node.IKRetargeterAsset->GetIKRigWriteable(ERetargetSourceOrTarget::Target));
+#else
 		PreloadObject(Node.IKRetargeterAsset->GetSourceIKRigWriteable());
 		PreloadObject(Node.IKRetargeterAsset->GetTargetIKRigWriteable());
+#endif
 	}
 }
+
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/MovementSampleEditor.Target.cs
+++ b/Source/MovementSampleEditor.Target.cs
@@ -14,8 +14,9 @@ public class MovementSampleEditorTarget : TargetRules
 	public MovementSampleEditorTarget(TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Editor;
-		DefaultBuildSettings = BuildSettingsVersion.V2;
+		DefaultBuildSettings = BuildSettingsVersion.V5;
+        IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 
-		ExtraModuleNames.AddRange(new string[] { "MovementSample" });
+        ExtraModuleNames.AddRange(new string[] { "MovementSample" });
 	}
 }


### PR DESCRIPTION
### Added support for Unreal Engine 5.4

- changed MovementSample.uproject to Unreal 5.4
- OculusXRRetargetIKRetargeterEditor.cpp: changed Getters to new methods of the IKRetargeter from Unreal Plugin "IKRig"
- MovementSampleEditor.Target.cs changed DefaultBuildSettings to V5 and IncludeOrderVersion to Latest (this breaks support for 5.3 but is required for 5.4)